### PR TITLE
Add way to distinguish committee head (FE)

### DIFF
--- a/src/components/CommitteeMembers.vue
+++ b/src/components/CommitteeMembers.vue
@@ -10,8 +10,12 @@
     <div class="title">Committee Members</div>
     <div class="divider"></div>
     <div class="content">
+      <div class="head" :key="committee.head">
+        <span>{{ committee.head }}</span>
+      </div>
       <div class="member" v-for="member in members" :key="member.id">
         <span>{{ member.id }}</span>
+
       </div>
     </div>
   </div>
@@ -23,7 +27,10 @@ export default {
   data () {
     return {
       members: null,
-      committee: { 'description': 'committee' }
+      committee: {
+        'description': 'committee',
+        'head': ''
+      }
     }
   },
   sockets: {
@@ -77,6 +84,22 @@ export default {
 
   .member span {
     background-color: #f36e21;
+    padding: 10px;
+    margin: 10px;
+    display: inline-block;
+    width: 80%;
+    text-align: center;
+  }
+
+  .head {
+    color: #fff;
+    font-size: 14pt;
+    font-weight: 300;
+    display: inline-block;
+    width: 25%;
+  }
+  .head span {
+    background-color: grey;
     padding: 10px;
     margin: 10px;
     display: inline-block;

--- a/src/components/CommitteeMembers.vue
+++ b/src/components/CommitteeMembers.vue
@@ -11,10 +11,8 @@
     <div class="divider"></div>
     <div class="content">
       <div class="head" :key="committee.head">
-        <div class="head-container">
-          <span class="head-label">HEAD</span>
-          <span class="head-content">{{ committee.head }}</span>
-        </div>
+        <span class="head-label">HEAD</span>
+          <span class="head-container">{{ committee.head }}</span>
       </div>
       <div class="member" v-for="member in members" :key="member.id">
         <span>{{ member.id }}</span>
@@ -95,28 +93,31 @@ export default {
   }
 
   .head {
+    FONT-WEIGHT: 300;
     color: #fff;
     font-size: 14pt;
     font-weight: 300;
     display: inline-block;
-    width: 25%;
   }
   .head-container {
     background-color: #f36e21;
     display: inline-block;
-    width: 80%;
-    margin: 10px;
+    padding: 10px 50px 10px 50px;
+    margin: 10px 0 10px 0;
     text-align: center;
   }
 
   .head-label {
     float: left;
-    writing-mode: vertical-rl; 
+    -webkit-writing-mode: vertical-rl;
+    -ms-writing-mode: tb-rl;
+    writing-mode: vertical-rl;
     background-color: #000;
     color: white;
     font-size: 0.7rem;
     letter-spacing: 0.05rem;
-    padding:0.2rem;
+    padding: 0.2rem;
+    margin: 10px 0 10px 10px;
   }
 
   .head-content {

--- a/src/components/CommitteeMembers.vue
+++ b/src/components/CommitteeMembers.vue
@@ -11,7 +11,10 @@
     <div class="divider"></div>
     <div class="content">
       <div class="head" :key="committee.head">
-        <span>{{ committee.head }}</span>
+        <div class="head-container">
+          <span class="head-label">HEAD</span>
+          <span class="head-content">{{ committee.head }}</span>
+        </div>
       </div>
       <div class="member" v-for="member in members" :key="member.id">
         <span>{{ member.id }}</span>
@@ -98,13 +101,27 @@ export default {
     display: inline-block;
     width: 25%;
   }
-  .head span {
-    background-color: grey;
-    padding: 10px;
-    margin: 10px;
+  .head-container {
+    background-color: #f36e21;
     display: inline-block;
     width: 80%;
+    margin: 10px;
     text-align: center;
+  }
+
+  .head-label {
+    float: left;
+    writing-mode: vertical-rl; 
+    background-color: #000;
+    color: white;
+    font-size: 0.7rem;
+    letter-spacing: 0.05rem;
+    padding:0.2rem;
+  }
+
+  .head-content {
+    padding: 10px;
+    vertical-align: middle;
   }
 
   .content {

--- a/src/components/CommitteeMembers.vue
+++ b/src/components/CommitteeMembers.vue
@@ -11,7 +11,7 @@
     <div class="divider"></div>
     <div class="content">
       <div class="head" :key="committee.head">
-        <span class="head-label">HEAD</span>
+          <span class="head-label">HEAD</span>
           <span class="head-container">{{ committee.head }}</span>
       </div>
       <div class="member" v-for="member in members" :key="member.id">
@@ -98,11 +98,12 @@ export default {
     font-size: 14pt;
     font-weight: 300;
     display: inline-block;
+    width: 24%;
   }
   .head-container {
     background-color: #f36e21;
     display: inline-block;
-    padding: 10px 50px 10px 50px;
+    padding: 10px 45px 10px 45px;
     margin: 10px 0 10px 0;
     text-align: center;
   }
@@ -121,8 +122,7 @@ export default {
   }
 
   .head-content {
-    padding: 10px;
-    vertical-align: middle;
+    width: 100%;
   }
 
   .content {

--- a/src/components/CommitteeMembers.vue
+++ b/src/components/CommitteeMembers.vue
@@ -93,7 +93,6 @@ export default {
   }
 
   .head {
-    FONT-WEIGHT: 300;
     color: #fff;
     font-size: 14pt;
     font-weight: 300;


### PR DESCRIPTION
**Background:**

There is currently no way to identify who is the committee head in the frontend. There should be a way in the frontend to visualize if a user is a committee head, so if someone has to talk with the head they know who to talk to.

**Location:**

The logic is located in components/CommitteeMembers.vue

 

**Solution:**

<img width="1044" alt="Screen Shot 2019-11-07 at 8 44 55 PM" src="https://user-images.githubusercontent.com/26098678/68443060-efee7a00-01a0-11ea-9c13-b98372a5c72e.png">
