### PR TITLE
TT-200 - Redirect after adding minutes

### DIFF
--- a/src/pages/Minutes.vue
+++ b/src/pages/Minutes.vue
@@ -122,7 +122,10 @@ export default {
         this.saveMinuteResponse.success = true
         this.saveMinuteResponse.message = data.success
       }
-      setTimeout(this.removeSaveMinuteResponse, 3000)
+      setTimeout(() => {
+        this.removeSaveMinuteResponse()
+        if (data.success) this.$router.push(`/committee/${this.minute.committee_id}`)
+      }, 3000)
     },
     edit_minute: function (data) {
       if (data.error) {

--- a/src/pages/Minutes.vue
+++ b/src/pages/Minutes.vue
@@ -54,13 +54,20 @@ export default {
   },
   data () {
     return {
-      minute: Object,
+      minute: {
+        id: null,
+        charges: [],
+        committee_id: '',
+        title: '',
+        body: '',
+        private: true
+      },
       mode: {
         VIEW: 'view',
         EDIT: 'edit',
         NEW: 'new'
       },
-      currentMode: String,
+      currentMode: '',
       backgroundImage: null,
       showLoadingIndicator: true,
       quill: null,


### PR DESCRIPTION
https://ritservices.atlassian.net/browse/TT-200

After a user (successfully) adds minutes they're presented with a success modal. After the modal disappears they are left on the minutes page. For a better UX they should be redirected to the committee's page on success.

This ticket redirects a user to the appropriate committee after they successfully add minutes.