### PR TITLE
TT-203 - When not logged in Auth bugs occur

### DIFF
--- a/src/components/ChargeAdmin.vue
+++ b/src/components/ChargeAdmin.vue
@@ -150,9 +150,6 @@ export default {
       this.$emit('updateCharge', Object.assign({}, this.charge, {[field]: event.target.value}))
     }
   },
-  mounted () {
-    this.$watch('charge', this.onProp)
-  },
   sockets: {
     edit_charge: function (data) {
       if (data.success) {

--- a/src/mixins/auth.js
+++ b/src/mixins/auth.js
@@ -49,8 +49,12 @@ let functions = {
             this.pageReloaded(localStorage.getItem('token'), data.admin, data.username)
             resolve(localStorage.getItem('token'))
           } else {
-            reject()
-            this.logout()
+            if (this.isAuthenticated()) {
+              reject()
+              this.logout()
+            } else {
+              resolve(null)
+            }
           }
         }
         var token = (process.env.AUTH_METHOD === 'LDAP') ? {token: localStorage.getItem('token')} : {}


### PR DESCRIPTION
https://ritservices.atlassian.net/browse/TT-203

When a user navigates to a committee, charge, or minutes page while they are not logged in, the page doesn't get populated with data. This is because the backend is set up in such a way that if you are not logged in, it returns an error. This error is not handled by the frontend so the page just looks broken.

To fix this I made changes to both the frontend and the backend. For the frontend I wanted to make as few changes as possible. Because of this I modified the logic only in the `checkAuth` function. What my solution does is make use of the already present `isAuthenticated` boolean. If this was previously true, then the user was logged in already but their token expired. This means they should be forced to log back in. If this flag is false, then they were not logged in already and the function resolves with a null token. This allows the frontend to make further requests to the backend without changing code elsewhere.

My main concern with this approach is that the error from `reject` wasn't being caught anywhere it could have been thrown before. I think that the way it is now, there could still be issues down the line where a user's who _is_ logged in has their token expire without any indication that they need to log in. There needs to be a catch block where `checkAuth` is called. That being said `checkAuth` can be called several times on the same page, so if there are indicators added we should try not to flood the user with too much info.

Although this wasn't explicitly part of the ticket, there's some weird behavior if an unauthenticated user tries to directly access a private minute (for example by going directly to `/minutes/{id}`). In this case they are presented with the editor to create new minutes which appears broken. There might be a need for a future ticket that redirects users if they try to directly access private entities.