### PR TITLE
Tt 211 : Delete Modal for notifications

### DIFF
--- a/src/components/DeleteNotificationModal.vue
+++ b/src/components/DeleteNotificationModal.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="modal is-clipped" v-bind:class="{ 'is-active': showModal }">
+    <div class="modal-background" v-on:click="$emit('closeDeleteModal')"></div>
+    <div class="modal-card">
+      <header class="modal-card-head">
+        <p class="modal-card-title">Are you sure you want to delete this notification?</p>
+      </header>
+      <footer class="modal-card-foot">
+        <button class="button is-primary" v-on:click="deleteNotification()">Delete Notification</button>
+        <button class="button" v-on:click="$emit('closeDeleteModal')">Cancel</button>
+      </footer>
+      <article class="message" v-if="deleteNotificationMessage.show" v-bind:class="deleteNotificationMessage.success ? 'is-success' : 'is-danger'">
+        <div class="message-body">{{ deleteNotificationMessage.message }}</div>
+      </article>
+    </div>
+  </div>
+</template>
+
+<script>
+  import Auth from '../mixins/auth'
+  export default {
+    name: 'DeleteNotificationModal',
+    mixins: [Auth],
+    data () {
+      return {
+        showModal: true,
+        deleteNotificationMessage: {
+          show: false,
+          message: null,
+          success: null
+        }
+      }
+    },
+    methods: {
+      deleteNotification () {
+        this.deleteNotificationMessage.show = true
+        this.deleteNotificationMessage.message = 'Notification Deleted'
+        this.deleteNotificationMessage.success = true
+        setTimeout(() => { this.$emit('deleteNotification') }, 2000)
+      }
+    }
+  }
+</script>
+
+<style scoped>
+  .modal-card{
+    overflow: visible;
+  }
+  .modal-card-body{
+    overflow: visible;
+  }
+  .vue-simple-suggest.designed .input-wrapper input{
+    font-display: 'Montserrat', Helvetica, Arial, sans-serif !important;
+    font-size: 1rem !important;
+  }
+
+  .select{
+    margin-bottom: 10%;
+  }
+</style>

--- a/src/components/HeaderMenu.vue
+++ b/src/components/HeaderMenu.vue
@@ -34,7 +34,7 @@ author: Gabe Landau <gll1872@rit.edu>
 
                 <a class="notification" v-bind:key="notification.id" v-for="notification in notifications" :value="notification">{{notification.message}}
                 <ul class="notificationButtons">
-                  <li class="delete"><button class="delete" @click="deleteNotifiction(notification)">Delete</button></li>
+                  <li class="delete"><button class="delete" @click="openDeleteModal(notification)">Delete</button></li>
                   <li class="open"><button class="open" @click="goToDestination(notification)">Open</button></li>
                 </ul>
                 </a>
@@ -80,6 +80,11 @@ author: Gabe Landau <gll1872@rit.edu>
       </div>
       </div>
     </div>
+
+    <div v-if="showDeleteModal">
+      <DeleteNotificationModal v-on:deleteNotification="deleteNotification()" v-on:closeDeleteModal="closeDeleteModal()"/>
+    </div>
+
   </div>
 </template>
 
@@ -88,12 +93,16 @@ var i
 import Auth from '../mixins/auth'
 import EventBus from './EventBus'
 import { mapGetters } from 'vuex'
+import DeleteNotificationModal from '@/components/DeleteNotificationModal.vue'
 
 export default {
   name: 'headermenu',
+  components: { 'DeleteNotificationModal': DeleteNotificationModal },
   mixins: [Auth],
   data () {
     return {
+      notificationToDelete: null,
+      showDeleteModal: false,
       test: false,
       notifications: [],
       menuMessages: [],
@@ -107,6 +116,14 @@ export default {
     }
   },
   methods: {
+    openDeleteModal (notification) {
+      this.showDeleteModal = true
+      this.notificationToDelete = notification
+    },
+    closeDeleteModal () {
+      this.showDeleteModal = false
+      this.notificationToDelete = null
+    },
     badgeController () {
       this.badgeNumber = 0
       for (i = 0; i < this.notifications.length; i++) {
@@ -120,10 +137,11 @@ export default {
         this.showBadge = false
       }
     },
-    deleteNotifiction (notification) {
-      var index = this.notifications.indexOf(notification)
-      this.notificationController('delete_notification', notification)
+    deleteNotification () {
+      var index = this.notifications.indexOf(this.notificationToDelete)
+      this.notificationController('delete_notification', this.notificationToDelete)
       this.notifications.splice(index, 1) // Splice is used to avoid 'holes' in the array
+      this.showDeleteModal = false
       this.badgeController()
     },
     notificationController (controllerType, notification) {

--- a/src/components/HeaderMenu.vue
+++ b/src/components/HeaderMenu.vue
@@ -131,7 +131,7 @@ export default {
           this.badgeNumber++
         }
       }
-      if (this.badgeNumber > 0) {
+      if (this.badgeNumber >= 0) {
         this.showBadge = true
       } else {
         this.showBadge = false

--- a/src/components/HeaderMenu.vue
+++ b/src/components/HeaderMenu.vue
@@ -27,15 +27,13 @@ author: Gabe Landau <gll1872@rit.edu>
         <div class="dropdown"> 
           <button class="btn notification_button" @click="toggleNotifications()"><i class="fa fa-bell notification_button"></i></button>
           <div><span v-if="showBadge" id="notificationBadge" class="w3-badge">{{ badgeNumber }}</span></div>
-
           <div id="notificationDropdown" class="dropdown-content form-control" name="people">
             <span>
               <div>
-
                 <a class="notification" v-bind:key="notification.id" v-for="notification in notifications" :value="notification">{{notification.message}}
                 <ul class="notificationButtons">
-                  <li class="delete"><button class="delete" @click="openDeleteModal(notification)">Delete</button></li>
-                  <li class="open"><button class="open" @click="goToDestination(notification)">Open</button></li>
+                  <li v-if="!noNotifications" class="delete"><button class="delete" @click="openDeleteModal(notification)">Delete</button></li>
+                  <li v-if="!noNotifications" class="open"><button class="open" @click="goToDestination(notification)">Open</button></li>
                 </ul>
                 </a>
               </div>
@@ -101,6 +99,7 @@ export default {
   mixins: [Auth],
   data () {
     return {
+      noNotifications: null,
       notificationToDelete: null,
       showDeleteModal: false,
       test: false,
@@ -131,10 +130,15 @@ export default {
           this.badgeNumber++
         }
       }
-      if (this.badgeNumber >= 0) {
+      if (this.badgeNumber > 0) {
+        this.noNotifications = false
         this.showBadge = true
       } else {
+        this.noNotifications = true
         this.showBadge = false
+        this.notifications.push({
+          message: 'No notifications yet...'
+        })
       }
     },
     deleteNotification () {


### PR DESCRIPTION
[Ticket tt-211](https://ritservices.atlassian.net/browse/TT-211?atlOrigin=eyJpIjoiOTk1NThjYTU0MDg3NDJkNzhlNTE1N2I4Njg2OTJiYTIiLCJwIjoiaiJ9)

[Ticket tt-213](https://ritservices.atlassian.net/browse/TT-213?atlOrigin=eyJpIjoiY2Q2ODZlOGE5ZTFmNDc1YTlhNWEwNDk0OWJlM2ZkMzQiLCJwIjoiaiJ9)

The purpose of this ticket was to implement an 'Are you sure?" modal before the user can delete a notification. The modal was added as a component to the HeaderMenu. I also added a message to the user to indicate when there are no notifications to show, so that the menu doesn't just appear broken if there aren't any notifications.

While it would be ideal to make this a reusable modal that we could use in multiple parts of TigerTracker, i realized that we don't really have many other areas where it would be useful, and doing so would be a rather large refactoring with not much benefit, so i made it a one-off modal.

No new tests should be needed for this one.
