### PR TITLE
TT-210 - Time of day displaying incorrectly for committees

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -314,7 +314,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -6165,8 +6164,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -7423,8 +7421,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -14380,8 +14377,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -14402,14 +14398,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -14424,20 +14418,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -14554,8 +14545,7 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -14567,7 +14557,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -14582,7 +14571,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -14590,14 +14578,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -14616,7 +14602,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -14706,8 +14691,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -14719,7 +14703,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -14805,8 +14788,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -14842,7 +14824,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -14862,7 +14843,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -14906,14 +14886,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/src/pages/Committee.vue
+++ b/src/pages/Committee.vue
@@ -181,7 +181,7 @@ export default {
           ampm = 'AM'
         }
 
-        minute = (committeeTime.length > 3 ? committeeTime.substring(2) : committeeTime.substring(1)).padStart(2, '0')
+        minute = committeeTime.length > 3 ? committeeTime.substring(2) : committeeTime.substring(1)
       }
 
       return {ampm, day, hour, minute}

--- a/src/pages/Committee.vue
+++ b/src/pages/Committee.vue
@@ -181,7 +181,7 @@ export default {
           ampm = 'AM'
         }
 
-        minute = committeeTime.substring(2).padStart(2, '0')
+        minute = (committeeTime.length > 3 ? committeeTime.substring(2) : committeeTime.substring(1)).padStart(2, '0')
       }
 
       return {ampm, day, hour, minute}

--- a/src/pages/Committee.vue
+++ b/src/pages/Committee.vue
@@ -56,7 +56,7 @@ import { mapGetters } from 'vuex'
 import Auth from '../mixins/auth'
 
 export default {
-  name: 'dashboard',
+  name: 'committee',
   mixins: [Auth],
   components: {
     'HeaderMenu': HeaderMenu,
@@ -113,66 +113,76 @@ export default {
     }
   },
   beforeMount () {
-    this.updatePage()
+    let committeeId = this.$router.history.current.params['committee']
+    this.updatePage(committeeId)
   },
   beforeRouteUpdate (to, from, next) {
-    this.updatePage()
+    let committeeId = to.params['committee']
+    this.updatePage(committeeId)
     next()
   },
   methods: {
-    updatePage () {
-      this.$socket.emit('get_committee', this.$router.history.current.params['committee'])
-      this.$socket.emit('get_members', this.$router.history.current.params['committee'])
+    updatePage (committeeId) {
+      this.$socket.emit('get_committee', committeeId)
+      this.$socket.emit('get_members', committeeId)
       this.checkAuth().then((token) => {
         this.$socket.emit('get_charges', {
           token: token,
-          committee_id: this.$router.history.current.params['committee']
+          committee_id: committeeId
         })
         this.$socket.emit('get_minutes', {
           token: token,
-          committee_id: this.$router.history.current.params['committee']
+          committee_id: committeeId
         })
       })
     },
-    convertTimeDay (oldDay, oldTime) {
+    convertTimeDay (committeeDay, committeeTime) {
       let day = ''
-      switch (oldDay) {
-        case 0:
-          day = 'Sunday'
-          break
-        case 1:
-          day = 'Monday'
-          break
-        case 2:
-          day = 'Tuesday'
-          break
-        case 3:
-          day = 'Wednesday'
-          break
-        case 4:
-          day = 'Thursday'
-          break
-        case 5:
-          day = 'Friday'
-          break
-        case 6:
-          day = 'Saturday'
-          break
-        default:
-          day = 'Sunday'
-      }
-
       let ampm = ''
-      let hour = parseInt(oldTime.substr(0, 2))
-      if (hour > 12) {
-        hour = hour - 12 + ''
-        ampm = 'PM'
-      } else {
-        hour = hour + ''
-        ampm = 'AM'
+      let hour = ''
+      let minute = ''
+
+      if (committeeDay != null) {
+        switch (committeeDay) {
+          case 0:
+            day = 'Sunday'
+            break
+          case 1:
+            day = 'Monday'
+            break
+          case 2:
+            day = 'Tuesday'
+            break
+          case 3:
+            day = 'Wednesday'
+            break
+          case 4:
+            day = 'Thursday'
+            break
+          case 5:
+            day = 'Friday'
+            break
+          case 6:
+            day = 'Saturday'
+            break
+          default:
+            day = 'Sunday'
+            break
+        }
       }
 
-      let minute = oldTime.substring(2, 5)
+      if (committeeTime != null) {
+        hour = committeeTime.length > 3 ? committeeTime.substring(0, 2) : committeeTime.substring(0, 1)
+        if (hour > 12) {
+          hour = hour - 12 + ''
+          ampm = 'PM'
+        } else {
+          hour = hour + ''
+          ampm = 'AM'
+        }
+
+        minute = committeeTime.substring(2).padStart(2, '0')
+      }
 
       return {ampm, day, hour, minute}
     }


### PR DESCRIPTION
https://ritservices.atlassian.net/browse/TT-210

The meeting times for committees was being parsed incorrectly if the meeting hour was a single digit and the meeting minute was 0 (e.g. 8:00). I changed the logic to check the length of the time string so it can be parsed correctly.