### PR TITLE
TT-209 - New task redirect opens wrong task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -314,6 +314,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -6164,7 +6165,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -7421,7 +7423,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -14377,7 +14380,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -14398,12 +14402,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -14418,17 +14424,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -14545,7 +14554,8 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -14557,6 +14567,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -14571,6 +14582,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -14578,12 +14590,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -14602,6 +14616,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -14691,7 +14706,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -14703,6 +14719,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -14788,7 +14805,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -14824,6 +14842,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -14843,6 +14862,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -14886,12 +14906,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/src/components/CreateTaskModal.vue
+++ b/src/components/CreateTaskModal.vue
@@ -1,0 +1,146 @@
+<template>
+  <modal 
+    class="add-task"
+    :response-message="addTaskResponse.message"
+    :response-success="addTaskResponse.success"
+    :show-modal="showModal"
+    @close-modal="hide"
+  >
+    <div class="field">
+      <label class="label">Task Name</label>
+      <div class="control">
+        <input class="input" type="text" placeholder="Task Name" v-model="taskData.title">
+      </div>
+    </div>
+
+    <div class="field">
+      <label class="label">Assignee</label>
+      <div class="control">
+        <vue-simple-suggest
+          v-model="taskData.assignee"
+          :list="memberSuggestions"
+          :filter-by-query="true"
+          :max-suggestions="5"
+          :min-length="0">
+        </vue-simple-suggest>
+      </div>
+    </div>
+
+    <div class="field">
+      <label class="label">Task Description</label>
+      <div class="control">
+        <textarea class="textarea" placeholder="Purpose and description of this task..." v-model="taskData.description"></textarea>
+      </div>
+    </div>
+
+    <template v-slot:footer>
+      <button class="button is-primary" @click="createTask">Create Task</button>
+    </template>
+  </modal>
+</template>
+
+<script>
+import Modal from './Modal'
+import Auth from '../mixins/auth'
+import VueSimpleSuggest from 'vue-simple-suggest/dist/cjs'
+import 'vue-simple-suggest/dist/styles.css'
+
+export default {
+  name: 'CreateTaskModal',
+  mixins: [Auth],
+  components: {
+    VueSimpleSuggest,
+    Modal
+  },
+  props: {
+    members: {
+      type: Array,
+      required: true
+    }
+  },
+  data () {
+    return {
+      showModal: false,
+      taskData: {
+        description: '',
+        assignee: '',
+        title: ''
+      },
+      addTaskResponse: {
+        success: true,
+        message: ''
+      }
+    }
+  },
+  methods: {
+    createTask () {
+      // switch to id if username
+      this.members.forEach((member) => {
+        if (this.taskData.assignee === member.name) {
+          this.taskData.assignee = member.id
+          return
+        }
+        if (this.taskData.assignee === member.id) {
+          return
+        }
+      })
+      this.$socket.emit('create_action', {
+        token: this.getToken(),
+        charge: this.$router.history.current.params['charge'],
+        assigned_to: this.taskData.assignee,
+        title: this.taskData.title,
+        description: this.taskData.description
+      })
+    },
+    hide () {
+      this.taskData.description = ''
+      this.taskData.assignee = ''
+      this.taskData.title = ''
+      this.addTaskResponse.success = true
+      this.addTaskResponse.message = ''
+      this.showModal = false
+    },
+    show () {
+      this.showModal = true
+    }
+  },
+  sockets: {
+    create_action: function (data) {
+      if (data.success) {
+        this.addTaskResponse.success = true
+        this.addTaskResponse.message = data.success
+        setTimeout(() => { this.hide() }, 2000)
+      } else if (data.error) {
+        this.addTaskResponse.success = false
+        this.addTaskResponse.message = data.error
+      }
+    }
+  },
+  computed: {
+    memberSuggestions () {
+      let suggestions = []
+      this.members.forEach(member => {
+        suggestions.push(member.id)
+        suggestions.push(member.name)
+      })
+      return suggestions
+    }
+  }
+}
+</script>
+
+<style scoped>
+  html, body {
+    overflow: hidden !important;
+  }
+  .add-task {
+    z-index: 1000;
+  }
+  .control {
+    padding-right: 20px;
+  }
+
+  .modal-content {
+    width: 60%;
+  }
+</style>

--- a/src/components/HeaderMenu.vue
+++ b/src/components/HeaderMenu.vue
@@ -164,7 +164,10 @@ export default {
       this.badgeController()
       // Local Storage used to open the Action modal on the landing page
       if (notification.type === 'AssignedToAction') {
-        localStorage.setItem('openModal', true)
+        let taskIndex = notification.message.indexOf(':') + 2
+        let taskTitle = notification.message.substring(taskIndex)
+        localStorage.setItem('openTaskModal', true)
+        localStorage.setItem('taskTitle', taskTitle)
       }
       this.$router.push(notification.redirect)
     },

--- a/src/components/HeaderMenu.vue
+++ b/src/components/HeaderMenu.vue
@@ -164,10 +164,12 @@ export default {
       this.badgeController()
       // Local Storage used to open the Action modal on the landing page
       if (notification.type === 'AssignedToAction') {
-        let taskIndex = notification.message.indexOf(':') + 2
-        let taskTitle = notification.message.substring(taskIndex)
-        localStorage.setItem('openTaskModal', true)
-        localStorage.setItem('taskTitle', taskTitle)
+        let taskId = parseInt(notification.destination)
+        if (!Number.isNaN(taskId)) {
+          this.$store.commit('taskId', {
+            taskId: taskId
+          })
+        }
       }
       this.$router.push(notification.redirect)
     },

--- a/src/components/HeaderMenu.vue
+++ b/src/components/HeaderMenu.vue
@@ -169,9 +169,9 @@ export default {
           this.$store.commit('taskId', {
             taskId: taskId
           })
+          this.$router.push(notification.redirect)
         }
       }
-      this.$router.push(notification.redirect)
     },
     submitLogin () {
       this.showAuthError = false

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="add-task modal" :class="{ 'is-active': showModal }">
+    <div class="modal-background" @click="closeModal"></div>
+    <div class="modal-content">
+      <div class="box">
+        <article class="message" v-if="responseMessage" :class="responseSuccess ? 'is-success' : 'is-danger'">
+          <div class="message-body">{{ responseMessage }}</div>
+        </article>
+        
+        <slot></slot>
+
+        <slot name="footer"></slot>
+      </div>
+    </div>
+    <button class="modal-close is-large" @click="closeModal"></button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Modal',
+  props: {
+    closeModal: {
+      type: Function,
+      required: true
+    },
+    showModal: {
+      type: Boolean,
+      default: false
+    },
+    responseMessage: {
+      type: String,
+      default: ''
+    },
+    responseSuccess: {
+      type: Boolean,
+      default: true
+    }
+  }
+}
+</script>

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="add-task modal" :class="{ 'is-active': showModal }">
+  <div class="modal" :class="{ 'is-active': showModal }">
     <div class="modal-background" @click="closeModal"></div>
     <div class="modal-content">
       <div class="box">
@@ -20,10 +20,6 @@
 export default {
   name: 'Modal',
   props: {
-    closeModal: {
-      type: Function,
-      required: true
-    },
     showModal: {
       type: Boolean,
       default: false
@@ -35,6 +31,11 @@ export default {
     responseSuccess: {
       type: Boolean,
       default: true
+    }
+  },
+  methods: {
+    closeModal () {
+      this.$emit('close-modal')
     }
   }
 }

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -175,9 +175,12 @@ export default {
   },
   beforeMount () {
     // Used for notification redirect
-    if (localStorage.openModal === 'true') {
-      this.active = true
-      localStorage.removeItem('openModal')
+    if (localStorage.openTaskModal === 'true') {
+      if (localStorage.taskTitle === this.task.title) {
+        this.active = true
+        localStorage.removeItem('openTaskModal')
+        localStorage.removeItem('taskTitle')
+      }
     }
     this.status = this.task.status
     switch (this.task.status) {

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -9,9 +9,9 @@ author: Gabe Landau <gll1872@rit.edu>
 
 <template>
   <div class="task">
-    <div @click="active = true">
+    <div @click="taskClicked">
       <div><h3 class="title is-3">{{task.title}}</h3></div>
-      <div class="taskList">
+      <div>
         <p>{{task.description}}</p>
       </div>
 
@@ -29,208 +29,27 @@ author: Gabe Landau <gll1872@rit.edu>
         </div>
       </div>
     </div>
-
-    <div class="task modal" v-bind:class="{ 'is-active': active }">
-      <div class="modal-background" @click="active = false"></div>
-        <div class="modal-content">
-          <div class="box">
-            <article class="message" v-if="createNoteResponseStatus" v-bind:class="createNoteResponseStatus === 'success' ? 'is-success' : 'is-danger'">
-              <div class="message-body">{{ createNoteResponseMessage }}</div>
-            </article>
-            <div class="modal-header">
-              <span class="icon"><i class="mdi header-icon" v-bind:class="[style, icon]"></i></span>
-              <span class="modal-titles">
-                <span class="modal-title">{{task.title}}</span><br />
-                <span class="modal-subtitle">Assigned to <span class="link">{{task.assigned_to}}</span></span>
-              </span>
-            </div>
-            <p>{{task.description}}</p>
-            <p class="updates-header">Updates ({{task.notes ? task.notes.length : 0}})</p>
-
-          <div class="update" v-for="note in task.notes" :key="note.id">
-            <div class="update-image">
-              <img src="../assets/avatar.png" />
-            </div>
-            <div class="update-body">
-              <div class="update-header">
-                <span class="update-name">{{note.author}}</span>
-                <span class="update-timestamp">Posted on {{note.created_at}}</span>
-              </div>
-              <p class="update-body-text">{{note.description}}</p>
-            </div>
-          </div>
-
-          <div class="modalForm">
-            <div class="field">
-              <div class="control">
-                <textarea class="textarea" placeholder="Write a comment or update..." v-model="createNoteText"></textarea>
-              </div>
-            </div>
-            <div class="field">
-              <button class="button is-primary" id="submitCommentButton" v-on:click="createNote()">Submit Comment</button>
-            </div>
-            <p class="updates-header">Admin</p>
-            <div class="field">
-              <div class="field has-addons">
-                <div class="control">
-                  <div class="select">
-                    <select name="country" v-model="status">
-                      <option value="0" selected>In Progress</option>
-                      <option value="1">Stopped</option>
-                      <option value="2">Complete</option>
-                      <option value="3">On Hold</option>
-                      <option value="4">Indefinite</option>
-                    </select>
-                  </div>
-                </div>
-                <div class="control">
-                  <button type="button" class="button is-primary" v-on:click="changeStatus()">Change Status</button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button class="modal-close is-large" @click="clearTaskModal"></button>
-    </div>
   </div>
 </template>
 
 <script>
-import Auth from '../mixins/auth'
-
 export default {
   name: 'task',
-  components: {},
   props: ['task'],
-  mixins: [Auth],
-  data () {
-    return {
-      active: false,
-      style: '',
-      icon: '',
-      id: null,
-      status: -1,
-      createNoteText: '',
-      createNoteResponseStatus: '',
-      createNoteResponseMessage: ''
-    }
-  },
-  sockets: {
-    create_note: function (data) {
-      if (data.success) {
-        this.active = true
-        this.createNoteResponseStatus = 'success'
-        this.createNoteResponseMessage = data.success
-        setTimeout(() => { this.clearTaskModal() }, 2000)
-      }
-      if (data.error) {
-        this.createNoteResponseStatus = 'error'
-        this.createNoteResponseMessage = data.error
-      } else {
-        this.createNoteText = ''
-      }
-    },
-    edit_action: function (data) {
-      if (data.error) {
-        this.createNoteResponseStatus = 'error'
-        this.createNoteResponseMessage = data.error
-      }
-    }
-  },
   methods: {
-    createNote () {
-      this.$socket.emit('create_note', {
-        token: this.getToken(),
-        action: this.task.id,
-        description: this.createNoteText
-      })
-    },
-    changeStatus () {
-      this.$socket.emit('edit_action', {
-        token: this.getToken(),
-        id: this.task.id,
-        status: this.status
-      })
-    },
-    clearTaskModal () {
-      this.active = false
-      this.style = ''
-      this.icon = ''
-      this.id = null
-      this.status = -1
-      this.createNoteText = ''
-      this.createNoteResponseStatus = ''
-      this.createNoteResponseMessage = ''
+    taskClicked () {
+      this.$emit('task-clicked', this.task)
     }
   },
   computed: {
-    recentNotes: function () {
-      if (this.task.notes) {
-        return this.task.notes.slice(this.task.notes.length - 2, this.task.notes.length)
-      } else {
-        return []
-      }
-    }
-  },
-  beforeMount () {
-    // Used for notification redirect
-    if (localStorage.openTaskModal === 'true') {
-      if (localStorage.taskTitle === this.task.title) {
-        this.active = true
-        localStorage.removeItem('openTaskModal')
-        localStorage.removeItem('taskTitle')
-      }
-    }
-    this.status = this.task.status
-    switch (this.task.status) {
-      case 0:
-        this.style = 'in-progress'
-        this.icon = 'mdi-play-circle-outline'
-        break
-      case 1:
-        this.style = 'stop'
-        this.icon = 'mdi-minus-circle-outline'
-        break
-      case 2:
-        this.style = 'complete'
-        this.icon = 'mdi-checkbox-marked-circle-outline'
-        break
-      case 3:
-        this.style = 'on-hold'
-        this.icon = 'mdi-pause-circle-outline'
-        break
-      case 4:
-        this.style = 'indefinite'
-        this.icon = 'mdi-information-outline'
-        break
+    recentNotes () {
+      return this.task.notes ? this.task.notes.slice(this.task.notes.length - 2, this.task.notes.length) : []
     }
   }
 }
 </script>
 
 <style scoped>
-  /* Statuses for icons */
-  .in-progress {
-    color: #d6b829;
-  }
-
-  .stop {
-    color: #f00;
-  }
-
-  .complete {
-    color: #088512;
-  }
-
-  .on-hold {
-    color: #ff8720;
-  }
-
-  .indefinite {
-    color: #4f86ff;
-  }
-
   /* Thumbnail styles */
   .task {
     padding: 10px;
@@ -239,66 +58,12 @@ export default {
     cursor: pointer;
   }
 
-  .thumbnail {
-    padding-left: 15px;
-  }
-
   h3 {
     margin-top: 0;
   }
 
-  .subtitle {
-    padding-left: 40px;
-    color: #7f7f7f;
-    font-size: 10pt;
-  }
-
-  /* Modal styles */
-  .modalForm {
-    padding-right: 20px;
-  }
-
-  .modal {
-    z-index: 100000;
-  }
-
-  .modal-content {
-    width: 60%;
-  }
-
-  .modal-header {
-    overflow: hidden;
-  }
-
-  .header-icon {
-    float: left;
-    font-size: 28pt;
-    vertical-align: middle;
-  }
-
-  .modal-titles {
-    float: left;
-    padding-left: 10px;
-  }
-
-  .modal-title {
-    font-size: 16pt;
-  }
-
-  .modal-subtitle {
-    color: #7f7f7f;
-  }
-
   .updates-header {
     font-weight: 700;
-  }
-
-  .link {
-    text-decoration: underline;
-  }
-
-  #submitCommentButton {
-    margin-right: 20px;
   }
 
   .update {

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -100,7 +100,7 @@ author: Gabe Landau <gll1872@rit.edu>
 import Auth from '../mixins/auth'
 
 export default {
-  name: 'tasks',
+  name: 'task',
   components: {},
   props: ['task'],
   mixins: [Auth],

--- a/src/components/TaskModal.vue
+++ b/src/components/TaskModal.vue
@@ -1,78 +1,287 @@
 <template>
-  <div class="task modal" v-bind:class="{ 'is-active': active }">
-    <div class="modal-background" @click="active = false"></div>
-      <div class="modal-content">
-        <div class="box">
-          <article class="message" v-if="createNoteResponseStatus" v-bind:class="createNoteResponseStatus === 'success' ? 'is-success' : 'is-danger'">
-            <div class="message-body">{{ createNoteResponseMessage }}</div>
-          </article>
-          <div class="modal-header">
-            <span class="icon"><i class="mdi header-icon" v-bind:class="[style, icon]"></i></span>
-            <span class="modal-titles">
-              <span class="modal-title">{{task.title}}</span><br />
-              <span class="modal-subtitle">Assigned to <span class="link">{{task.assigned_to}}</span></span>
-            </span>
-          </div>
-          <p>{{task.description}}</p>
-          <p class="updates-header">Updates ({{task.notes ? task.notes.length : 0}})</p>
+  <modal
+    :response-message="createNoteResponse.message"
+    :response-success="createNoteResponse.success"
+    :show-modal="showModal"
+    @close-modal="hide"
+  >
+    <div class="modal-header">
+      <span class="icon"><i class="mdi header-icon" v-bind:class="[style, icon]"></i></span>
+      <span class="modal-titles">
+        <span class="modal-title">{{task.title}}</span><br />
+        <span class="modal-subtitle">Assigned to <span class="link">{{task.assigned_to}}</span></span>
+      </span>
+    </div>
+    <p>{{task.description}}</p>
+    <p class="updates-header">Updates ({{task.notes ? task.notes.length : 0}})</p>
 
-        <div class="update" v-for="note in task.notes" :key="note.id">
-          <div class="update-image">
-            <img src="../assets/avatar.png" />
-          </div>
-          <div class="update-body">
-            <div class="update-header">
-              <span class="update-name">{{note.author}}</span>
-              <span class="update-timestamp">Posted on {{note.created_at}}</span>
-            </div>
-            <p class="update-body-text">{{note.description}}</p>
-          </div>
+    <div class="update" v-for="note in task.notes" :key="note.id">
+      <div class="update-image">
+        <img src="../assets/avatar.png" />
+      </div>
+      <div class="update-body">
+        <div class="update-header">
+          <span class="update-name">{{note.author}}</span>
+          <span class="update-timestamp">Posted on {{note.created_at}}</span>
         </div>
+        <p class="update-body-text">{{note.description}}</p>
+      </div>
+    </div>
 
-        <div class="modalForm">
-          <div class="field">
-            <div class="control">
-              <textarea class="textarea" placeholder="Write a comment or update..." v-model="createNoteText"></textarea>
+    <div class="modal-form">
+      <div class="field">
+        <div class="control">
+          <textarea class="textarea" placeholder="Write a comment or update..." v-model="createNoteText"></textarea>
+        </div>
+      </div>
+      <div class="field">
+        <button class="button is-primary" id="submitCommentButton" @click="createNote()">Submit Comment</button>
+      </div>
+      <p class="updates-header">Admin</p>
+      <div class="field">
+        <div class="field has-addons">
+          <div class="control">
+            <div class="select">
+              <select name="country" v-model="status">
+                <option value="0" selected>In Progress</option>
+                <option value="1">Stopped</option>
+                <option value="2">Complete</option>
+                <option value="3">On Hold</option>
+                <option value="4">Indefinite</option>
+              </select>
             </div>
           </div>
-          <div class="field">
-            <button class="button is-primary" id="submitCommentButton" v-on:click="createNote()">Submit Comment</button>
-          </div>
-          <p class="updates-header">Admin</p>
-          <div class="field">
-            <div class="field has-addons">
-              <div class="control">
-                <div class="select">
-                  <select name="country" v-model="status">
-                    <option value="0" selected>In Progress</option>
-                    <option value="1">Stopped</option>
-                    <option value="2">Complete</option>
-                    <option value="3">On Hold</option>
-                    <option value="4">Indefinite</option>
-                  </select>
-                </div>
-              </div>
-              <div class="control">
-                <button type="button" class="button is-primary" v-on:click="changeStatus()">Change Status</button>
-              </div>
-            </div>
+          <div class="control">
+            <button type="button" class="button is-primary" v-on:click="changeStatus()">Change Status</button>
           </div>
         </div>
       </div>
     </div>
-    <button class="modal-close is-large" @click="clearTaskModal"></button>
-  </div>
+  </modal>
 </template>
 
 <script>
-export default {
-    name: 'TaskModal',
-    props: {
-        task: {
-            type: Object,
-            required: true
-        }
-    },
+import Modal from './Modal'
+import Auth from '../mixins/auth'
 
+export default {
+  name: 'TaskModal',
+  components: {
+    Modal
+  },
+  mixins: [Auth],
+  props: {
+    task: {
+      type: Object,
+      required: true
+    }
+  },
+  data () {
+    return {
+      noteText: '',
+      status: this.task.status,
+      showModal: false,
+      createNoteResponse: {
+        success: true,
+        message: ''
+      }
+    }
+  },
+  computed: {
+    style () {
+      switch (this.task.status) {
+        case 0:
+          return 'in-progress'
+          break
+        case 1:
+          return 'stop'
+          break
+        case 2:
+          return 'complete'
+          break
+        case 3:
+          return 'on-hold'
+          break
+        case 4:
+        default:
+          return 'indefinite'
+          break
+      }
+    },
+    icon () {
+      switch (this.task.status) {
+        case 0:
+          return 'mdi-play-circle-outline'
+          break
+        case 1:
+          return 'mdi-minus-circle-outline'
+          break
+        case 2:
+          return 'mdi-minus-circle-outline'
+          break
+        case 3:
+          return 'mdi-pause-circle-outline'
+          break
+        case 4:
+        default:
+          return 'mdi-information-outline'
+          break
+      }
+    }
+  },
+  methods: {
+    createNote () {
+      this.$socket.emit('create_note', {
+        token: this.getToken(),
+        action: this.task.id,
+        description: this.noteText
+      })
+    },
+    changeStatus () {
+      this.$socket.emit('edit_action', {
+        token: this.getToken(),
+        id: this.task.id,
+        status: this.status
+      })
+    },
+    hide () {
+      this.createNoteResponse.success = true
+      this.createNoteResponse.message = ''
+      this.noteText = ''
+      this.status = null
+      this.showModal = false
+    },
+    show () {
+      this.showModal = true
+    }
+  },
+  sockets: {
+    create_note: function (data) {
+      if (data.success) {
+        this.createNoteResponse.success = true
+        this.createNoteResponse.message = data.success
+        setTimeout(() => { this.hide() }, 2000)
+      }
+      if (data.error) {
+        this.createNoteResponse.success = false
+        this.createNoteResponse.message = data.error
+      } else {
+        this.noteText = ''
+      }
+    },
+    edit_action: function (data) {
+      if (data.error) {
+        this.createNoteResponse.success = false
+        this.createNoteResponse.message = data.error
+      }
+    }
+  },
 }
 </script>
+
+<style scoped>
+  /* Statuses for icons */
+  .in-progress {
+    color: #d6b829;
+  }
+
+  .stop {
+    color: #f00;
+  }
+
+  .complete {
+    color: #088512;
+  }
+
+  .on-hold {
+    color: #ff8720;
+  }
+
+  .indefinite {
+    color: #4f86ff;
+  }
+
+  /* Modal styles */
+  .modal-form {
+    padding-right: 20px;
+  }
+
+  .modal-header {
+    overflow: hidden;
+  }
+
+  .header-icon {
+    float: left;
+    font-size: 28pt;
+    vertical-align: middle;
+  }
+
+  .modal-titles {
+    float: left;
+    padding-left: 10px;
+  }
+
+  .modal-title {
+    font-size: 16pt;
+  }
+
+  .modal-subtitle {
+    color: #7f7f7f;
+  }
+
+  .updates-header {
+    font-weight: 700;
+  }
+
+  .link {
+    text-decoration: underline;
+  }
+
+  #submitCommentButton {
+    margin-right: 20px;
+  }
+
+  .update {
+    overflow: hidden;
+    padding-left: 10px;
+    padding-bottom: 10px;
+  }
+
+  .update-image {
+    float: left;
+  }
+
+  .update-body {
+    padding-left: 20px;
+    padding-bottom: 10px;
+    overflow:hidden;
+    word-wrap: break-word;
+    float:none
+  }
+
+  .update-body-text {
+    font-size: 11pt;
+  }
+
+  .update-header {
+    line-height: 16pt;
+  }
+
+  .update-name {
+    font-size: 16pt;
+  }
+
+  .update-timestamp {
+    vertical-align: top;
+    font-size: 10pt;
+    text-decoration: underline;
+  }
+
+  .update-image img {
+    height: 65px;
+    border-radius: 50%;
+    -moz-border-radius: 50%;
+    -webkit-border-radius: 50%;
+    border: 1px solid #404040;
+  }
+</style>

--- a/src/components/TaskModal.vue
+++ b/src/components/TaskModal.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="task modal" v-bind:class="{ 'is-active': active }">
+    <div class="modal-background" @click="active = false"></div>
+      <div class="modal-content">
+        <div class="box">
+          <article class="message" v-if="createNoteResponseStatus" v-bind:class="createNoteResponseStatus === 'success' ? 'is-success' : 'is-danger'">
+            <div class="message-body">{{ createNoteResponseMessage }}</div>
+          </article>
+          <div class="modal-header">
+            <span class="icon"><i class="mdi header-icon" v-bind:class="[style, icon]"></i></span>
+            <span class="modal-titles">
+              <span class="modal-title">{{task.title}}</span><br />
+              <span class="modal-subtitle">Assigned to <span class="link">{{task.assigned_to}}</span></span>
+            </span>
+          </div>
+          <p>{{task.description}}</p>
+          <p class="updates-header">Updates ({{task.notes ? task.notes.length : 0}})</p>
+
+        <div class="update" v-for="note in task.notes" :key="note.id">
+          <div class="update-image">
+            <img src="../assets/avatar.png" />
+          </div>
+          <div class="update-body">
+            <div class="update-header">
+              <span class="update-name">{{note.author}}</span>
+              <span class="update-timestamp">Posted on {{note.created_at}}</span>
+            </div>
+            <p class="update-body-text">{{note.description}}</p>
+          </div>
+        </div>
+
+        <div class="modalForm">
+          <div class="field">
+            <div class="control">
+              <textarea class="textarea" placeholder="Write a comment or update..." v-model="createNoteText"></textarea>
+            </div>
+          </div>
+          <div class="field">
+            <button class="button is-primary" id="submitCommentButton" v-on:click="createNote()">Submit Comment</button>
+          </div>
+          <p class="updates-header">Admin</p>
+          <div class="field">
+            <div class="field has-addons">
+              <div class="control">
+                <div class="select">
+                  <select name="country" v-model="status">
+                    <option value="0" selected>In Progress</option>
+                    <option value="1">Stopped</option>
+                    <option value="2">Complete</option>
+                    <option value="3">On Hold</option>
+                    <option value="4">Indefinite</option>
+                  </select>
+                </div>
+              </div>
+              <div class="control">
+                <button type="button" class="button is-primary" v-on:click="changeStatus()">Change Status</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <button class="modal-close is-large" @click="clearTaskModal"></button>
+  </div>
+</template>
+
+<script>
+export default {
+    name: 'TaskModal',
+    props: {
+        task: {
+            type: Object,
+            required: true
+        }
+    },
+
+}
+</script>

--- a/src/components/TaskModal.vue
+++ b/src/components/TaskModal.vue
@@ -31,11 +31,11 @@
     <div class="modal-form">
       <div class="field">
         <div class="control">
-          <textarea class="textarea" placeholder="Write a comment or update..." v-model="createNoteText"></textarea>
+          <textarea class="textarea" placeholder="Write a comment or update..." v-model="noteText"></textarea>
         </div>
       </div>
       <div class="field">
-        <button class="button is-primary" id="submitCommentButton" @click="createNote()">Submit Comment</button>
+        <button class="button is-primary" id="submitCommentButton" @click="createNote">Submit Comment</button>
       </div>
       <p class="updates-header">Admin</p>
       <div class="field">
@@ -92,40 +92,30 @@ export default {
       switch (this.task.status) {
         case 0:
           return 'in-progress'
-          break
         case 1:
           return 'stop'
-          break
         case 2:
           return 'complete'
-          break
         case 3:
           return 'on-hold'
-          break
         case 4:
         default:
           return 'indefinite'
-          break
       }
     },
     icon () {
       switch (this.task.status) {
         case 0:
           return 'mdi-play-circle-outline'
-          break
         case 1:
           return 'mdi-minus-circle-outline'
-          break
         case 2:
           return 'mdi-minus-circle-outline'
-          break
         case 3:
           return 'mdi-pause-circle-outline'
-          break
         case 4:
         default:
           return 'mdi-information-outline'
-          break
       }
     }
   },
@@ -175,7 +165,7 @@ export default {
         this.createNoteResponse.message = data.error
       }
     }
-  },
+  }
 }
 </script>
 

--- a/src/components/Tasks.vue
+++ b/src/components/Tasks.vue
@@ -16,16 +16,16 @@ author: Gabe Landau <gll1872@rit.edu>
         </div>
       </div>
       <div class="taskbar">
-        <span class="icon" v-bind:class="{ 'active_task': active_task === 0 }" v-on:click="makeActive(0)"><i class="mdi mdi-play-circle-outline"></i> {{ tasks.filter(task => task.status == 0).length }} In Progress</span>
-        <span class="icon" v-bind:class="{ 'active_task': active_task === 1 }" v-on:click="makeActive(1)"><i class="mdi mdi-minus-circle-outline"></i> {{ tasks.filter(task => task.status == 1).length }} Stopped</span>
-        <span class="icon" v-bind:class="{ 'active_task': active_task === 2 }" v-on:click="makeActive(2)"><i class="mdi mdi-checkbox-marked-circle-outline"></i> {{ tasks.filter(task => task.status == 2).length }} Completed</span>
-        <span class="icon" v-bind:class="{ 'active_task': active_task === 3 }" v-on:click="makeActive(3)"><i class="mdi mdi-pause-circle-outline"></i> {{ tasks.filter(task => task.status == 3).length }} On Hold</span>
-        <span class="icon" v-bind:class="{ 'active_task': active_task === 4 }" v-on:click="makeActive(4)"><i class="mdi mdi-information-outline"></i> {{ tasks.filter(task => task.status == 4).length }} Indefinite</span>
+        <span class="icon" :class="{ 'active_task': active_task === 0 }" @click="makeActive(0)"><i class="mdi mdi-play-circle-outline"></i> {{ tasks.filter(task => task.status == 0).length }} In Progress</span>
+        <span class="icon" :class="{ 'active_task': active_task === 1 }" @click="makeActive(1)"><i class="mdi mdi-minus-circle-outline"></i> {{ tasks.filter(task => task.status == 1).length }} Stopped</span>
+        <span class="icon" :class="{ 'active_task': active_task === 2 }" @click="makeActive(2)"><i class="mdi mdi-checkbox-marked-circle-outline"></i> {{ tasks.filter(task => task.status == 2).length }} Completed</span>
+        <span class="icon" :class="{ 'active_task': active_task === 3 }" @click="makeActive(3)"><i class="mdi mdi-pause-circle-outline"></i> {{ tasks.filter(task => task.status == 3).length }} On Hold</span>
+        <span class="icon" :class="{ 'active_task': active_task === 4 }" @click="makeActive(4)"><i class="mdi mdi-information-outline"></i> {{ tasks.filter(task => task.status == 4).length }} Indefinite</span>
       </div>
     </div>
 
-    <Task v-for="task in filteredTasks" :key="task.id" v-bind:task="task"/>
-
+    <Task v-for="task in filteredTasks" :key="task.id" :task="task" @task-clicked="showTaskModal"/>
+    <task-modal ref="taskModal" :task="selectedTask"/>
     <create-task-modal ref="createTaskModal" :members="members"/>
   </div>
 </template>
@@ -36,58 +36,35 @@ import Auth from '../mixins/auth'
 import VueSimpleSuggest from 'vue-simple-suggest/dist/cjs'
 import 'vue-simple-suggest/dist/styles.css'
 import CreateTaskModal from './CreateTaskModal'
+import TaskModal from './TaskModal'
 
 export default {
   name: 'tasks',
   mixins: [Auth],
   props: ['tasks', 'committee'],
   components: {
-    'Task': Task,
-    'VueSimpleSuggest': VueSimpleSuggest,
-    'CreateTaskModal': CreateTaskModal
+    Task,
+    VueSimpleSuggest,
+    TaskModal,
+    CreateTaskModal
   },
   data () {
     return {
-      showAddTaskForm: false,
       active_task: 0,
-      createTaskData: {
-        title: '',
-        description: '',
-        assignee: ''
-      },
-      addTaskResponse: {
-        show: false,
-        success: null,
-        message: null
-      },
+      selectedTask: {},
       members: []
     }
   },
   methods: {
-    createTask () {
-      // switch to id if username
-      this.members.forEach((member) => {
-        if (this.createTaskData.assignee === member.name) {
-          this.createTaskData.assignee = member.id
-          return
-        }
-        if (this.createTaskData.assignee === member.id) {
-          return
-        }
-      })
-      this.$socket.emit('create_action', {
-        token: this.getToken(),
-        charge: this.$router.history.current.params['charge'],
-        assigned_to: this.createTaskData.assignee,
-        title: this.createTaskData.title,
-        description: this.createTaskData.description
-      })
-    },
     makeActive (status) {
       this.active_task = status
     },
     showCreateTaskModal () {
       this.$refs.createTaskModal.show()
+    },
+    showTaskModal (task) {
+      this.selectedTask = task
+      this.$refs.taskModal.show()
     }
   },
   sockets: {
@@ -108,30 +85,9 @@ export default {
 
 <style scoped>
   @import "../../node_modules/mdi/css/materialdesignicons.css";
-  /* Statuses for icons */
-  .in-progress {
-    color: #d6b829;
-  }
-  .stop {
-    color: #f00;
-  }
-  .complete {
-    color: #088512;
-  }
-  .on-hold {
-    color: #ff8720;
-  }
-  .indefinite {
-    color: #4f86ff;
-  }
+
   html, body {
     overflow: hidden !important;
-  }
-  .add-task {
-    z-index: 1000;
-  }
-  .control {
-    padding-right: 20px;
   }
   .tasks {
     background-color: #fff;
@@ -182,8 +138,5 @@ export default {
   .active_task {
     color: white !important;
     background-color: #f36e21;
-  }
-  .modal-content {
-    width: 60%;
   }
 </style>

--- a/src/components/Tasks.vue
+++ b/src/components/Tasks.vue
@@ -12,7 +12,7 @@ author: Gabe Landau <gll1872@rit.edu>
           <div class="tasks_title">Tasks</div>
         </div>
         <div class="column">
-          <button class="tasks_button button is-primary" @click="showAddTaskForm = true">New</button>
+          <button class="tasks_button button is-primary" @click="showCreateTaskModal">New</button>
         </div>
       </div>
       <div class="taskbar">
@@ -26,45 +26,7 @@ author: Gabe Landau <gll1872@rit.edu>
 
     <Task v-for="task in filteredTasks" :key="task.id" v-bind:task="task"/>
 
-    <div class="add-task modal" v-bind:class="{ 'is-active': showAddTaskForm }">
-      <div class="modal-background" @click="clearTaskModal()"></div>
-      <div class="modal-content">
-        <div class="box">
-          <article class="message" v-if="addTaskResponse.show" v-bind:class="addTaskResponse.success ? 'is-success' : 'is-danger'">
-            <div class="message-body">{{ addTaskResponse.message }}</div>
-          </article>
-          <div class="field">
-            <label class="label">Task Name</label>
-            <div class="control">
-              <input class="input" type="text" placeholder="Task Name" v-model="createTaskData.title">
-            </div>
-          </div>
-
-          <div class="field">
-            <label class="label">Assignee</label>
-            <div class="control">
-              <vue-simple-suggest
-                v-model="createTaskData.assignee"
-                :list="memberSuggestions"
-                :filter-by-query="true"
-                :max-suggestions="5"
-                :min-length="0">
-              </vue-simple-suggest>
-            </div>
-          </div>
-
-          <div class="field">
-            <label class="label">Task Description</label>
-            <div class="control">
-              <textarea class="textarea" placeholder="Purpose and description of this task..." v-model="createTaskData.description"></textarea>
-            </div>
-          </div>
-
-          <button class="button is-primary" @click="createTask()">Create Task</button>
-        </div>
-      </div>
-      <button class="modal-close is-large" @click="clearTaskModal"></button>
-    </div>
+    <create-task-modal ref="createTaskModal" :members="members"/>
   </div>
 </template>
 
@@ -73,13 +35,16 @@ import Task from './Task'
 import Auth from '../mixins/auth'
 import VueSimpleSuggest from 'vue-simple-suggest/dist/cjs'
 import 'vue-simple-suggest/dist/styles.css'
+import CreateTaskModal from './CreateTaskModal'
+
 export default {
   name: 'tasks',
   mixins: [Auth],
   props: ['tasks', 'committee'],
   components: {
     'Task': Task,
-    'VueSimpleSuggest': VueSimpleSuggest
+    'VueSimpleSuggest': VueSimpleSuggest,
+    'CreateTaskModal': CreateTaskModal
   },
   data () {
     return {
@@ -95,8 +60,7 @@ export default {
         success: null,
         message: null
       },
-      members: [],
-      memberSuggestions: []
+      members: []
     }
   },
   methods: {
@@ -122,35 +86,13 @@ export default {
     makeActive (status) {
       this.active_task = status
     },
-    clearTaskModal () {
-      this.showAddTaskForm = false
-      this.createTaskData.title = ''
-      this.createTaskData.description = ''
-      this.createTaskData.assignee = ''
-      this.addTaskResponse.show = false
-      this.addTaskResponse.success = null
-      this.addTaskResponse.message = null
+    showCreateTaskModal () {
+      this.$refs.createTaskModal.show()
     }
   },
   sockets: {
-    create_action: function (data) {
-      if (data.success) {
-        this.addTaskResponse.success = true
-        this.addTaskResponse.show = true
-        this.addTaskResponse.message = data.success
-        setTimeout(() => { this.clearTaskModal() }, 2000)
-      } else if (data.error) {
-        this.addTaskResponse.success = false
-        this.addTaskResponse.show = true
-        this.addTaskResponse.message = data.error
-      }
-    },
     get_members: function (data) {
       this.members = data.members
-      this.members.forEach((member) => {
-        this.memberSuggestions.push(member.id)
-        this.memberSuggestions.push(member.name)
-      })
     }
   },
   beforeMount () {

--- a/src/components/Tasks.vue
+++ b/src/components/Tasks.vue
@@ -33,6 +33,7 @@ author: Gabe Landau <gll1872@rit.edu>
 <script>
 import Task from './Task'
 import Auth from '../mixins/auth'
+import { mapGetters } from 'vuex'
 import VueSimpleSuggest from 'vue-simple-suggest/dist/cjs'
 import 'vue-simple-suggest/dist/styles.css'
 import CreateTaskModal from './CreateTaskModal'
@@ -78,6 +79,23 @@ export default {
   computed: {
     filteredTasks: function () {
       return this.tasks.filter(task => task.status === this.active_task)
+    },
+    ...mapGetters({
+      taskId: 'taskId'
+    })
+  },
+  watch: {
+    tasks (newTasks, oldTasks) {
+      let selectedTask = newTasks.find(task => task.id === this.taskId)
+      if (selectedTask) {
+        this.showTaskModal(selectedTask)
+      }
+    },
+    taskId (newTaskId, oldTaskId) {
+      let selectedTask = this.tasks.find(task => task.id === newTaskId)
+      if (selectedTask) {
+        this.showTaskModal(selectedTask)
+      }
     }
   }
 }

--- a/src/pages/Charge.vue
+++ b/src/pages/Charge.vue
@@ -80,13 +80,13 @@ export default {
     }
   },
   beforeMount () {
-    this.checkAuth().then((token) => {
-      this.$socket.emit('get_charge', {
-        token: token,
-        charge: this.$router.history.current.params['charge']
-      })
-      this.$socket.emit('get_actions', this.$router.history.current.params['charge'])
-    })
+    let chargeId = this.$router.history.current.params['charge']
+    this.updatePage(chargeId)
+  },
+  beforeRouteUpdate (to, from, next) {
+    let chargeId = to.params['charge']
+    this.updatePage(chargeId)
+    next()
   },
   methods: {
     redirect () {
@@ -94,6 +94,15 @@ export default {
     },
     updateCharge (updatedCharge) {
       this.charge = updatedCharge
+    },
+    updatePage (chargeId) {
+      this.checkAuth().then((token) => {
+        this.$socket.emit('get_charge', {
+          token: token,
+          charge: chargeId
+        })
+        this.$socket.emit('get_actions', chargeId)
+      })
     }
   }
 }

--- a/src/pages/Charge.vue
+++ b/src/pages/Charge.vue
@@ -12,15 +12,15 @@ author: Gabe Landau <gll1872@rit.edu>
     <HeaderMenu />
     <CommitteesMenu />
     <div class="charge_header">
-      <div class="charge_header_text">{{ this.charge.title }}</div>
+      <div class="charge_header_text">{{ charge.title }}</div>
       <div class="charge_header_tag">
-        <button class="redirect_button" @click="redirect()">{{ this.charge.committee }}</button>
+        <button class="redirect_button" @click="redirect()">{{ charge.committee }}</button>
       </div>
     </div>
-    <ChargeAdmin @updateCharge ="updateCharge" v-bind:charge="this.charge"/>
-    <ChargeStatusBar v-bind:actions="this.actions"/>
-    <Purpose v-bind:chargeDesc="this.charge.description" v-bind:createdAt="this.charge.created_at" />
-    <Tasks v-if="this.charge.committee != ''" v-bind:tasks="actions" v-bind:committee="this.charge.committee" />
+    <ChargeAdmin @updateCharge="updateCharge" :charge="charge"/>
+    <ChargeStatusBar :actions="actions"/>
+    <Purpose :chargeDesc="charge.description" :createdAt="charge.created_at" />
+    <Tasks v-if="charge.committee" :tasks="actions" :committee="charge.committee" />
   </div>
 </template>
 
@@ -35,7 +35,7 @@ import moment from 'moment'
 import Auth from '../mixins/auth'
 
 export default {
-  name: 'dashboard',
+  name: 'charge',
   mixins: [Auth],
   components: {
     'HeaderMenu': HeaderMenu,

--- a/src/pages/Committee.vue
+++ b/src/pages/Committee.vue
@@ -19,7 +19,7 @@ author: Gabe Landau <gll1872@rit.edu>
     </div>
 
     <CommitteeOverview :inProgressCount="inProgressCount" :incompleteCount="incompleteCount" :completedCount="completedCount" :indefiniteCount="indefiniteCount" :stoppedCount="stoppedCount" />
-    <CommitteeAdmin v-if="inCommittee || admin" :committee="committee" :is-privileged="committee.head == username || admin" @chargeCreated="updatePage"/>
+    <CommitteeAdmin v-if="inCommittee || admin" :committee="committee" :is-privileged="committee.head == username || admin" @chargeCreated="updatePage(committee.id)"/>
     <CommitteeMembers :members="members" :committee-head="committee.head"/>
     <div class="tabs is-boxed is-centered">
       <ul>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,7 +8,8 @@ export default new Vuex.Store({
     token: '',
     username: '',
     admin: false,
-    authenticated: false
+    authenticated: false,
+    taskId: null
   },
   mutations: {
     token (state, data) {
@@ -22,6 +23,9 @@ export default new Vuex.Store({
     },
     authenticated (state, data) {
       state.authenticated = data.authenticated
+    },
+    taskId (state, data) {
+      state.taskId = data.taskId
     }
   },
   getters: {
@@ -29,6 +33,7 @@ export default new Vuex.Store({
     admin: state => state.admin,
     username: state => state.username,
     authenticated: state => state.authenticated,
-    isLdap: state => process.env.AUTH_METHOD === 'LDAP'
+    isLdap: state => process.env.AUTH_METHOD === 'LDAP',
+    taskId: state => state.taskId
   }
 })


### PR DESCRIPTION
https://ritservices.atlassian.net/browse/TT-209

Currently when a user is assigned to a task under a charge, they receive a notification telling them so. When they click on this notification, they get redirected to the charge page, and a modal opens showing them the task they were assigned to. 

If more than one task exists under a charge, then the modal opens the first task, even if that was not the one the user is assigned to. This pull request fixes this, so that right model gets shown.

I honestly don't like my solution at all. It looks at the message of the notification to find the name of the task that they were assigned to, and does a string comparison to figure out if it should open a modal or not. I don't like the solution because it depends on the message for the assignment notification to be in a similar form for it to work. If the format for this kind of notification changes in the future, this redirect will break.
