### PR TITLE
TT-221 - Allow redirect for notification types other than task assignment

### DIFF
--- a/src/components/HeaderMenu.vue
+++ b/src/components/HeaderMenu.vue
@@ -162,7 +162,6 @@ export default {
         notification.viewed = true
       }
       this.badgeController()
-      // Local Storage used to open the Action modal on the landing page
       if (notification.type === 'AssignedToAction') {
         let taskId = parseInt(notification.destination)
         if (!Number.isNaN(taskId)) {

--- a/src/components/HeaderMenu.vue
+++ b/src/components/HeaderMenu.vue
@@ -171,6 +171,8 @@ export default {
           })
           this.$router.push(notification.redirect)
         }
+      } else {
+        this.$router.push(notification.redirect)
       }
     },
     submitLogin () {


### PR DESCRIPTION
https://ritservices.atlassian.net/browse/TT-221

Moving the `$router.push()` inside of the `AssignedToAction` conditional prevents other notification types from properly redirecting. This PR adds an else that attempts the redirect if the notification type isn't `AssignedToAction`. In the future it might make sense to have more if statements or a switch for notification type so we can make sure each destination is formatted like the frontend expects.