### PR TITLE
TT-235 - Committee Head Styling

### DIFF
--- a/src/components/CommitteeMembers.vue
+++ b/src/components/CommitteeMembers.vue
@@ -89,7 +89,7 @@ export default {
     color: #fff;
     font-size: 14pt;
     font-weight: 300;
-    display: inline-block;
+    display: inline-flex;
   }
   .head-container {
     background-color: #f36e21;


### PR DESCRIPTION
https://ritservices.atlassian.net/browse/TT-235

This PR is to fix a styling issue on the committee page. There is a vertical label to denote who the committee head is that is styled incorrectly on Safari. This change fixes the styling so that everything appears as intended.

No tests were written because this is a styling change only; I did view the page on Firefox and Chrome to make sure nothing was broken by this change.