### PR TITLE
Update head-label margin

### DIFF
--- a/src/components/CommitteeMembers.vue
+++ b/src/components/CommitteeMembers.vue
@@ -109,6 +109,6 @@ export default {
     font-size: 0.7rem;
     letter-spacing: 0.05rem;
     padding: 0.2rem;
-    margin: 10px 0 10px 10px;
+    margin: 10px 0 10px 0;
   }
 </style>


### PR DESCRIPTION
The committee head label had a margin that pushes the container too far to the left.