### PR TITLE
TT-231 - Hide charge controls if regular user

### DIFF
--- a/src/pages/Charge.vue
+++ b/src/pages/Charge.vue
@@ -14,8 +14,8 @@ author: Gabe Landau <gll1872@rit.edu>
     <div class="charge_header">
       <div class="charge_header_text">{{ charge.title }}</div>
       <div class="charge_header_tag">
-        <span><button class="redirect_button" @click="redirect('committee')">{{ this.charge.committee }}</button></span>
-        <span v-if="this.charge.paw_links"><button class="redirect_button" @click="redirect('paw_links')">Paw Links</button></span>
+        <span><button class="redirect_button" @click="redirect('committee')">{{ charge.committee }}</button></span>
+        <span v-if="charge.paw_links"><button class="redirect_button" @click="redirect('paw_links')">Paw Links</button></span>
       </div>
     </div>
     <ChargeAdmin v-if="isPrivileged" @updateCharge="updateCharge" :charge="charge"/>

--- a/src/pages/Charge.vue
+++ b/src/pages/Charge.vue
@@ -18,10 +18,10 @@ author: Gabe Landau <gll1872@rit.edu>
         <span v-if="this.charge.paw_links"><button class="redirect_button" @click="redirect('paw_links')">Paw Links</button></span>
       </div>
     </div>
-    <ChargeAdmin @updateCharge ="updateCharge" :charge="charge"/>
+    <ChargeAdmin v-if="isPrivileged" @updateCharge="updateCharge" :charge="charge"/>
     <ChargeStatusBar :actions="actions"/>
     <Purpose :chargeDesc="charge.description" :createdAt="charge.created_at" />
-    <Tasks v-if="charge.committee != ''" :tasks="actions" :committee="charge.committee" />
+    <Tasks v-if="charge.committee" :tasks="actions" :committee="charge.committee" />
   </div>
 </template>
 
@@ -33,6 +33,7 @@ import Tasks from '../components/Tasks'
 import Purpose from '../components/Purpose'
 import ChargeAdmin from '../components/ChargeAdmin'
 import moment from 'moment'
+import { mapGetters } from 'vuex'
 import Auth from '../mixins/auth'
 
 export default {
@@ -52,21 +53,25 @@ export default {
         title: '',
         committee: ''
       },
-      actions: []
+      actions: [],
+      members: []
     }
   },
   sockets: {
-    get_charge: function (data) {
+    get_charge (data) {
       this.charge = data
       this.charge.created_at = this.charge.created_at.substring(5, 7) + '/' + this.charge.created_at.substring(8, 10) + '/' + this.charge.created_at.substring(0, 4)
     },
-    get_actions: function (data) {
+    get_actions (data) {
       this.actions = data
       for (let action of this.actions) {
         this.$socket.emit('get_notes', action.id)
       }
     },
-    get_notes: function (data) {
+    get_members (data) {
+      this.members = data.error ? [] : data.members
+    },
+    get_notes (data) {
       if (data.length > 0) {
         for (let note of data) {
           note.created_at = moment(note.created_at).format('L @ h:mma')
@@ -104,6 +109,7 @@ export default {
       this.charge = updatedCharge
     },
     updatePage (chargeId) {
+      this.$socket.emit('get_members', this.charge.committee)
       this.checkAuth().then((token) => {
         this.$socket.emit('get_charge', {
           token: token,
@@ -111,6 +117,16 @@ export default {
         })
         this.$socket.emit('get_actions', chargeId)
       })
+    }
+  },
+  computed: {
+    ...mapGetters([
+      'admin',
+      'username'
+    ]),
+    isPrivileged () {
+      let isHead = this.members.some(member => member.id === this.username && member.role === 'CommitteeHead')
+      return this.admin || isHead
     }
   }
 }


### PR DESCRIPTION
https://ritservices.atlassian.net/browse/TT-231

The component to edit and close a charge was visible to users even if they were not an admin or committee head. This PR prevents this component from rendering if the user is not an admin or committee head.

The solution I used before follows the pattern I started with the change to the `Tasks` component that checks if the user is part of the committee or an admin. No unit tests have been written for this PR.